### PR TITLE
添加红黑树及测试

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@
 BASE_DIR := $(CURDIR)
 export BASE_DIR
 
-submod = binary btree lock list
+submod = binary btree lock list rbtree
 
 test:
 	for mod in $(submod); do ( cd $$mod && $(MAKE) test; ) done

--- a/src/rbtree/Makefile
+++ b/src/rbtree/Makefile
@@ -1,0 +1,8 @@
+
+src       = rbtree.c
+target    = rbtree.a
+
+test_exec = test_rbtree
+
+BASE_DIR ?= $(CURDIR)/..
+include $(BASE_DIR)/def.mk

--- a/src/rbtree/rbtree.c
+++ b/src/rbtree/rbtree.c
@@ -1,0 +1,458 @@
+#include "rbtree.h"
+
+int st_rbtree_init(st_rbtree_t *tree, st_rbtree_compare_pt cmp)
+{
+    st_must(tree != NULL, ST_ARG_INVALID);
+    st_must(cmp != NULL, ST_ARG_INVALID);
+
+    memset(tree, 0, sizeof(*tree));
+
+    st_rbtree_black(&tree->sentinel);
+
+    tree->root = &tree->sentinel;
+    tree->cmp = cmp;
+
+    return ST_OK;
+}
+
+st_rbtree_node_t * st_rbtree_left_most(st_rbtree_t *tree)
+{
+    st_rbtree_node_t *node = NULL;
+    st_rbtree_node_t *sentinel = &tree->sentinel;
+
+    node = tree->root;
+
+    if (node == sentinel) {
+        return NULL;
+    }
+
+    while (node->left != sentinel) {
+        node = node->left;
+    }
+
+    return node;
+}
+
+st_rbtree_node_t * st_rbtree_right_most(st_rbtree_t *tree)
+{
+    st_rbtree_node_t *node = NULL;
+    st_rbtree_node_t *sentinel = &tree->sentinel;
+
+    node = tree->root;
+
+    if (node == sentinel) {
+        return NULL;
+    }
+
+    while (node->right != sentinel) {
+        node = node->right;
+    }
+
+    return node;
+}
+
+static void st_rbtree_left_rotate(st_rbtree_node_t **root, st_rbtree_node_t *sentinel,
+        st_rbtree_node_t *node)
+{
+    st_rbtree_node_t  *child;
+
+    /*
+     *     (N)           (C)
+     *     / \           / \
+     *   (X) (C)  ->   (N) (CR)
+     *       / \       / \
+     *    (CL) (CR)  (X) (CL)
+     */
+
+    child = node->right;
+    node->right = child->left;
+
+    if (child->left != sentinel) {
+        child->left->parent = node;
+    }
+
+    child->parent = node->parent;
+
+    if (node == *root) {
+        *root = child;
+
+    } else if (st_rbtree_is_left_child(node)) {
+        node->parent->left = child;
+
+    } else {
+        node->parent->right = child;
+    }
+
+    child->left = node;
+    node->parent = child;
+}
+
+static void st_rbtree_right_rotate(st_rbtree_node_t **root, st_rbtree_node_t *sentinel,
+        st_rbtree_node_t *node)
+{
+    st_rbtree_node_t  *child;
+
+    child = node->left;
+    node->left = child->right;
+
+    if (child->right != sentinel) {
+        child->right->parent = node;
+    }
+
+    child->parent = node->parent;
+
+    if (node == *root) {
+        *root = child;
+
+    } else if (st_rbtree_is_right_child(node)) {
+        node->parent->right = child;
+
+    } else {
+        node->parent->left = child;
+    }
+
+    child->right = node;
+    node->parent = child;
+}
+
+static int insert_node(st_rbtree_t *tree, st_rbtree_node_t *node)
+{
+    st_rbtree_node_t *curr = tree->root;
+    st_rbtree_node_t  **p = NULL;
+    st_rbtree_node_t *sentinel = &tree->sentinel;
+
+    if (tree->root == sentinel) {
+        node->parent = NULL;
+        node->left = sentinel;
+        node->right = sentinel;
+        st_rbtree_black(node);
+        tree->root = node;
+
+        // no need rebalance
+        return 0;
+    }
+
+    while (1) {
+
+        if (tree->cmp(node, curr) < 0) {
+            p = &curr->left;
+        } else {
+            p = &curr->right;
+        }
+
+        if (*p == sentinel) {
+            break;
+        }
+
+        curr = *p;
+    }
+
+    *p = node;
+    node->parent = curr;
+    node->left = sentinel;
+    node->right = sentinel;
+    st_rbtree_red(node);
+
+    // need rebalance
+    return 1;
+}
+
+int st_rbtree_insert(st_rbtree_t *tree, st_rbtree_node_t *node)
+{
+    st_rbtree_node_t  **root, *uncle, *sentinel;
+    int need_rebalance;
+
+    st_must(tree != NULL, ST_ARG_INVALID);
+    st_must(node != NULL, ST_ARG_INVALID);
+
+    root = (st_rbtree_node_t **) &tree->root;
+    sentinel = &tree->sentinel;
+
+    need_rebalance = insert_node(tree, node);
+    if (need_rebalance == 0) {
+        return ST_OK;
+    }
+
+    /* insert fixup, re-balance tree */
+
+    while (node != *root && st_rbtree_is_red(node->parent)) {
+
+        if (st_rbtree_is_left_child(node->parent)) {
+            uncle = node->parent->parent->right;
+
+            if (st_rbtree_is_red(uncle)) {
+                st_rbtree_black(node->parent);
+                st_rbtree_black(uncle);
+                st_rbtree_red(node->parent->parent);
+                node = node->parent->parent;
+
+            } else {
+                if (st_rbtree_is_right_child(node)) {
+                    node = node->parent;
+                    st_rbtree_left_rotate(root, sentinel, node);
+                }
+
+                st_rbtree_black(node->parent);
+                st_rbtree_red(node->parent->parent);
+                st_rbtree_right_rotate(root, sentinel, node->parent->parent);
+            }
+
+        } else {
+            uncle = node->parent->parent->left;
+
+            if (st_rbtree_is_red(uncle)) {
+                st_rbtree_black(node->parent);
+                st_rbtree_black(uncle);
+                st_rbtree_red(node->parent->parent);
+                node = node->parent->parent;
+
+            } else {
+                if (st_rbtree_is_left_child(node)) {
+                    node = node->parent;
+                    st_rbtree_right_rotate(root, sentinel, node);
+                }
+
+                st_rbtree_black(node->parent);
+                st_rbtree_red(node->parent->parent);
+                st_rbtree_left_rotate(root, sentinel, node->parent->parent);
+            }
+        }
+    }
+
+    st_rbtree_black(*root);
+
+    return ST_OK;
+}
+
+static st_rbtree_node_t * get_left_most(st_rbtree_node_t *node, st_rbtree_node_t *sentinel) {
+
+    while (node->left != sentinel) {
+        node = node->left;
+    }
+
+    return node;
+}
+
+static st_rbtree_node_t * delete_node(st_rbtree_t *tree, st_rbtree_node_t *node)
+{
+    uint8_t red;
+    st_rbtree_node_t **root, *successor, *child;
+    st_rbtree_node_t *sentinel = &tree->sentinel;
+
+    root = (st_rbtree_node_t **) &tree->root;
+
+    // get successor and his child
+    if (node->left == sentinel) {
+        successor = node;
+        child = node->right;
+
+    } else if (node->right == sentinel) {
+        successor = node;
+        child = node->left;
+
+    } else {
+        successor = get_left_most(node->right, sentinel);
+        child = successor->right;
+    }
+
+    // delete if node is root
+    if (successor == *root) {
+        *root = child;
+        st_rbtree_black(child);
+
+        node->left = NULL;
+        node->right = NULL;
+        node->parent = NULL;
+
+        return NULL;
+    }
+
+    red = st_rbtree_is_red(successor);
+
+    // replace successor position from his child
+    if (st_rbtree_is_left_child(successor)) {
+        successor->parent->left = child;
+
+    } else {
+        successor->parent->right = child;
+    }
+
+    if (successor == node) {
+
+        // Case 1: node to erase has no more than 1 child
+        child->parent = successor->parent;
+
+    } else {
+
+        if (successor->parent == node) {
+            /*
+             * Case 2: node's successor is its right child
+             *
+             *     (n)          (s)
+             *     / \          / \
+             *   (x) (s)  ->  (x) (c)
+             *         \
+             *         (c)
+             */
+
+            child->parent = successor;
+
+        } else {
+            /*
+             *  Case 3: node's successor is leftmost under
+             *  node's right child subtree
+             *
+             *     (n)          (s)
+             *     / \          / \
+             *   (x) (y)  ->  (x) (y)
+             *       /            /
+             *     (p)          (p)
+             *     /            /
+             *   (s)          (c)
+             *     \
+             *     (c)
+             */
+
+            child->parent = successor->parent;
+        }
+
+        successor->left = node->left;
+        successor->right = node->right;
+        successor->parent = node->parent;
+        st_rbtree_copy_color(successor, node);
+
+        if (node == *root) {
+            *root = successor;
+
+        } else {
+            if (st_rbtree_is_left_child(node)) {
+                node->parent->left = successor;
+            } else {
+                node->parent->right = successor;
+            }
+        }
+
+        if (successor->left != sentinel) {
+            successor->left->parent = successor;
+        }
+
+        if (successor->right != sentinel) {
+            successor->right->parent = successor;
+        }
+    }
+
+    node->left = NULL;
+    node->right = NULL;
+    node->parent = NULL;
+
+    if (red) {
+        return NULL;
+    }
+
+    return child;
+}
+
+int st_rbtree_delete(st_rbtree_t *tree, st_rbtree_node_t *node)
+{
+    st_rbtree_node_t **root, *brother, *rebalance, *sentinel;
+
+    st_must(tree != NULL, ST_ARG_INVALID);
+    st_must(node != NULL, ST_ARG_INVALID);
+
+    root = (st_rbtree_node_t **) &tree->root;
+    sentinel = &tree->sentinel;
+
+    rebalance = delete_node(tree, node);
+    if (rebalance == NULL) {
+        return ST_OK;
+    }
+
+    /* delete fixup, re-balance tree */
+
+    while (rebalance != *root && st_rbtree_is_black(rebalance)) {
+
+        if (st_rbtree_is_left_child(rebalance)) {
+            brother = rebalance->parent->right;
+
+            if (st_rbtree_is_red(brother)) {
+                st_rbtree_black(brother);
+                st_rbtree_red(rebalance->parent);
+                st_rbtree_left_rotate(root, sentinel, rebalance->parent);
+                brother = rebalance->parent->right;
+            }
+
+            if (st_rbtree_is_black(brother->left) && st_rbtree_is_black(brother->right)) {
+                st_rbtree_red(brother);
+                rebalance = rebalance->parent;
+
+            } else {
+                if (st_rbtree_is_black(brother->right)) {
+                    st_rbtree_black(brother->left);
+                    st_rbtree_red(brother);
+                    st_rbtree_right_rotate(root, sentinel, brother);
+                    brother = rebalance->parent->right;
+                }
+
+                st_rbtree_copy_color(brother, rebalance->parent);
+                st_rbtree_black(rebalance->parent);
+                st_rbtree_black(brother->right);
+                st_rbtree_left_rotate(root, sentinel, rebalance->parent);
+                rebalance = *root;
+            }
+
+        } else {
+            brother = rebalance->parent->left;
+
+            if (st_rbtree_is_red(brother)) {
+                st_rbtree_black(brother);
+                st_rbtree_red(rebalance->parent);
+                st_rbtree_right_rotate(root, sentinel, rebalance->parent);
+                brother = rebalance->parent->left;
+            }
+
+            if (st_rbtree_is_black(brother->left) && st_rbtree_is_black(brother->right)) {
+                st_rbtree_red(brother);
+                rebalance = rebalance->parent;
+
+            } else {
+                if (st_rbtree_is_black(brother->left)) {
+                    st_rbtree_black(brother->right);
+                    st_rbtree_red(brother);
+                    st_rbtree_left_rotate(root, sentinel, brother);
+                    brother = rebalance->parent->left;
+                }
+
+                st_rbtree_copy_color(brother, rebalance->parent);
+                st_rbtree_black(rebalance->parent);
+                st_rbtree_black(brother->left);
+                st_rbtree_right_rotate(root, sentinel, rebalance->parent);
+                rebalance = *root;
+            }
+        }
+    }
+
+    st_rbtree_black(rebalance);
+
+    return ST_OK;
+}
+
+st_rbtree_node_t *s3_rbtree_search(st_rbtree_t *tree, st_rbtree_node_t *node) {
+
+    st_rbtree_node_t *curr = tree->root;
+    st_rbtree_node_t *sentinel = &tree->sentinel;
+    int ret;
+
+    while (curr != sentinel) {
+
+        ret = tree->cmp(node, curr);
+        if (ret < 0) {
+            curr = curr->left;
+        } else if (ret > 0) {
+            curr = curr->right;
+        } else {
+            return curr;
+        }
+    }
+
+    return NULL;
+}

--- a/src/rbtree/rbtree.h
+++ b/src/rbtree/rbtree.h
@@ -1,0 +1,67 @@
+#ifndef _RBTREE_H_INCLUDED_
+#define _RBTREE_H_INCLUDED_
+
+#include <stdint.h>
+#include <string.h>
+#include "inc/err.h"
+#include "inc/log.h"
+#include "inc/util.h"
+
+typedef struct st_rbtree_node_s  st_rbtree_node_t;
+typedef struct st_rbtree_s  st_rbtree_t;
+typedef int (*st_rbtree_compare_pt) (st_rbtree_node_t *a, st_rbtree_node_t *b);
+
+struct st_rbtree_node_s {
+    st_rbtree_node_t *left;
+    st_rbtree_node_t *right;
+    st_rbtree_node_t *parent;
+    uint8_t color;
+};
+
+struct st_rbtree_s {
+    st_rbtree_node_t *root;
+    st_rbtree_node_t sentinel;
+    st_rbtree_compare_pt cmp;
+};
+
+int st_rbtree_init(st_rbtree_t *tree, st_rbtree_compare_pt cmp);
+int st_rbtree_insert(st_rbtree_t *tree, st_rbtree_node_t *node);
+int st_rbtree_delete(st_rbtree_t *tree, st_rbtree_node_t *node);
+
+st_rbtree_node_t * st_rbtree_left_most(st_rbtree_t *tree);
+st_rbtree_node_t * st_rbtree_right_most(st_rbtree_t *tree);
+st_rbtree_node_t *s3_rbtree_search(st_rbtree_t *tree, st_rbtree_node_t *node);
+
+static inline void st_rbtree_red(st_rbtree_node_t *node) {
+    node->color = 1;
+}
+
+static inline void st_rbtree_black(st_rbtree_node_t *node) {
+    node->color = 0;
+}
+
+static inline void st_rbtree_copy_color(st_rbtree_node_t *n1, st_rbtree_node_t *n2) {
+    n1->color = n2->color;
+}
+
+static inline int st_rbtree_is_empty(st_rbtree_t *tree) {
+    return tree->root == &tree->sentinel;
+}
+
+static inline int st_rbtree_is_red(st_rbtree_node_t *node) {
+    return node->color;
+}
+
+static inline int st_rbtree_is_black(st_rbtree_node_t *node) {
+    return !st_rbtree_is_red(node);
+}
+
+static inline int st_rbtree_is_left_child(st_rbtree_node_t *node) {
+    return node == node->parent->left;
+}
+
+static inline int st_rbtree_is_right_child(st_rbtree_node_t *node) {
+    return node == node->parent->right;
+}
+
+#endif /* _RBTREE_H_INCLUDED_ */

--- a/src/rbtree/test_rbtree.c
+++ b/src/rbtree/test_rbtree.c
@@ -1,0 +1,291 @@
+#include "unittest/unittest.h"
+#include "rbtree.h"
+
+typedef struct test_object {
+    st_rbtree_node_t rb_node;
+    int64_t key;
+} test_object;
+
+static int rbtree_cmp(st_rbtree_node_t *a, st_rbtree_node_t *b) {
+
+    test_object *oa = (test_object *)a;
+    test_object *ob = (test_object *)b;
+
+    if (oa->key > ob->key) {
+        return 1;
+    } else if (oa->key < ob->key) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+st_test(rbtree, init) {
+
+    st_rbtree_t tree;
+
+    st_ut_eq(ST_ARG_INVALID, st_rbtree_init(NULL, rbtree_cmp), "tree arg should not be NULL");
+
+    st_ut_eq(ST_ARG_INVALID, st_rbtree_init(&tree, NULL), "cmp arg should not be NULL");
+
+    st_ut_eq(ST_OK, st_rbtree_init(&tree, rbtree_cmp), "rbtree_init ok");
+
+    st_ut_eq(&tree.sentinel, tree.root, "root should be sentinel");
+    st_ut_eq(&rbtree_cmp, tree.cmp, "compare should be equal rbtree_cmp");
+}
+
+st_test(rbtree, left_most) {
+
+    st_rbtree_t tree;
+    st_rbtree_node_t *node;
+
+    st_rbtree_init(&tree, rbtree_cmp);
+
+    node = st_rbtree_left_most(&tree);
+    st_ut_eq(NULL, node, "no value, so left_most get NULl");
+
+    test_object objects[] = {
+        {.key = 50},
+        {.key = 40},
+        {.key = 30},
+        {.key = 20},
+        {.key = 10},
+    };
+
+    for (int i = 0; i < st_nelts(objects); i++) {
+        st_rbtree_insert(&tree, &objects[i].rb_node);
+
+        test_object *obj = (test_object *)st_rbtree_left_most(&tree);
+
+        st_ut_eq(objects[i].key, obj->key, "compare left_most value");
+    }
+}
+
+st_test(rbtree, right_most) {
+
+    st_rbtree_t tree;
+    st_rbtree_node_t *node;
+
+    st_rbtree_init(&tree, rbtree_cmp);
+
+    node = st_rbtree_right_most(&tree);
+    st_ut_eq(NULL, node, "no value, so right_most get NULl");
+
+    test_object objects[] = {
+        {.key = 10},
+        {.key = 20},
+        {.key = 30},
+        {.key = 40},
+        {.key = 50},
+    };
+
+    for (int i = 0; i < st_nelts(objects); i++) {
+        st_rbtree_insert(&tree, &objects[i].rb_node);
+
+        test_object *obj = (test_object *)st_rbtree_right_most(&tree);
+
+        st_ut_eq(objects[i].key, obj->key, "compare right_most value");
+    }
+}
+
+st_test(rbtree, empty) {
+
+    st_rbtree_t tree;
+
+    st_rbtree_init(&tree, rbtree_cmp);
+
+    st_ut_eq(1, st_rbtree_is_empty(&tree), "rbtree is empty");
+
+    test_object object = {.key = 1};
+    st_rbtree_insert(&tree, &object.rb_node);
+
+    st_ut_eq(0, st_rbtree_is_empty(&tree), "rbtree is not empty");
+}
+
+st_test(rbtree, search) {
+
+    st_rbtree_t tree;
+    test_object *obj;
+    test_object tmp;
+    test_object objects[1000];
+
+    st_rbtree_init(&tree, rbtree_cmp);
+
+    tmp.key = 11;
+    obj = (test_object *)s3_rbtree_search(&tree, &tmp.rb_node);
+    st_ut_eq(NULL, obj, "tree is empty");
+
+    for (int i = 0; i < 1000; i++) {
+
+        // not add same key in rbtree
+        while (1) {
+            tmp.key = random() % 100000;
+            obj = (test_object *)s3_rbtree_search(&tree, &tmp.rb_node);
+            if (obj == NULL) {
+                break;
+            }
+        }
+
+        objects[i].key = tmp.key;
+        st_rbtree_insert(&tree, &objects[i].rb_node);
+    }
+
+    for (int i = 0; i < 1000; i++) {
+        tmp.key = objects[i].key;
+        obj = (test_object *)s3_rbtree_search(&tree, &tmp.rb_node);
+        st_ut_eq(&objects[i], obj, "found object");
+    }
+
+    tmp.key = 100000 + 1;
+    obj = (test_object *)s3_rbtree_search(&tree, &tmp.rb_node);
+    st_ut_eq(NULL, obj, "not found key");
+}
+
+void test_insert_with_search(int object_num) {
+
+    st_rbtree_t tree;
+    test_object *obj;
+    test_object objects[1000];
+    test_object tmp;
+
+    st_rbtree_init(&tree, rbtree_cmp);
+
+    for (int i = 0; i < object_num; i++) {
+        objects[i].key = i;
+
+        st_rbtree_insert(&tree, &objects[i].rb_node);
+
+        for (int j = 0; j <= i; j++) {
+            tmp.key = objects[j].key;
+
+            obj = (test_object *)s3_rbtree_search(&tree, &tmp.rb_node);
+
+            st_ut_eq(&objects[j], obj, "search object is right");
+        }
+    }
+}
+
+st_test(rbtree, insert) {
+
+    int test_object_num[] = {1, 100, 1000};
+
+    for (int i = 0; i < st_nelts(test_object_num); i++) {
+        test_insert_with_search(test_object_num[i]);
+    }
+}
+
+void test_delete_with_search(int object_num) {
+
+    st_rbtree_t tree;
+    st_rbtree_node_t *node;
+    test_object *obj;
+    test_object objects[1000];
+    test_object tmp;
+
+    st_rbtree_init(&tree, rbtree_cmp);
+
+    for (int i = 0; i < object_num; i++) {
+        objects[i].key = i;
+        st_rbtree_insert(&tree, &objects[i].rb_node);
+    }
+
+    for (int i = object_num-1; i >= 0; i--) {
+        tmp.key = objects[i].key;
+        obj = (test_object *)s3_rbtree_search(&tree, &tmp.rb_node);
+        st_ut_eq(&objects[i], obj, "search object is right");
+
+        node = &objects[i].rb_node;
+        st_rbtree_delete(&tree, node);
+
+        obj = (test_object *)s3_rbtree_search(&tree, &tmp.rb_node);
+        st_ut_eq(NULL, obj, "object has been deleted");
+
+        for (int j = 0; j <= i-1; j++) {
+            tmp.key = objects[j].key;
+            obj = (test_object *)s3_rbtree_search(&tree, &tmp.rb_node);
+            st_ut_eq(&objects[j], obj, "search object is right");
+        }
+    }
+}
+
+st_test(rbtree, delete) {
+
+    int test_object_num[] = {1, 100, 1000};
+
+    for (int i = 0; i < st_nelts(test_object_num); i++) {
+        test_delete_with_search(test_object_num[i]);
+    }
+}
+
+void test_add_with_delete(int object_num, int average_add, int average_delete) {
+
+    st_rbtree_t tree;
+    st_rbtree_node_t *node;
+    test_object *obj;
+    test_object tmp;
+    int start;
+    int end;
+    test_object objects[1000];
+
+    st_rbtree_init(&tree, rbtree_cmp);
+
+    int i = 0;
+
+    //test add some node and delete some node, than search all the node in rbtree
+    while (i < object_num) {
+
+        // add average_add num node into rbtree
+        for (int j = 0; j < average_add; j++) {
+            objects[i].key = i;
+            st_rbtree_insert(&tree, &objects[i].rb_node);
+            i++;
+        }
+
+        // delete average_delete num node from rbtree
+        for (int j = i - average_delete; j < i; j++) {
+            node = &objects[j].rb_node;
+            st_rbtree_delete(&tree, node);
+        }
+
+        for (int j = 0; j < i; j++) {
+            start = (j / average_add) * average_add;
+            end = start + average_add - average_delete;
+
+            tmp.key = objects[j].key;
+
+            // check the node wether has been deleted
+            if (j >= start && j < end) {
+                obj = (test_object *)s3_rbtree_search(&tree, &tmp.rb_node);
+                st_ut_eq(&objects[j], obj, "found object");
+            } else {
+                obj = (test_object *)s3_rbtree_search(&tree, &tmp.rb_node);
+                st_ut_eq(NULL, obj, "object has been deleted");
+            }
+        }
+    }
+}
+
+st_test(rbtree, add_with_delete) {
+
+    struct case_s {
+        int obj_num;
+        int average_add;
+        int average_delete;
+    } cases[] = {
+        {100*10, 100, 1},
+        {100*10, 100, 50},
+        {100*10, 100, 99},
+
+        {10*100, 10, 1},
+        {10*100, 10, 5},
+        {10*100, 10, 9},
+    };
+
+
+    for (int i = 0; i < st_nelts(cases); i++) {
+        st_typeof(cases[0]) c = cases[i];
+        test_add_with_delete(c.obj_num, c.average_add, c.average_delete);
+    }
+}
+
+st_ut_main;


### PR DESCRIPTION
添加红黑树及测试，
尝试将代码中的sentinel用NULL代替，测试的时候出现多种段错误。
算法导论中对红黑树的实现，使用sentinel，并将sentinel的颜色设置为黑色。
所以使用算法导轮实现，可以将叶子节点当成一个节点，设置黑色、判断颜色、使用叶子节点的空间等操作。但是如果设置成NULL,设置黑色、判断颜色可以通过代码兼容，但是在叶子节点的空间操作，类似node->child->left之类的，容易出现段错误。

所以又恢复成使用sentinel的实现。