### PR TITLE
str: add functions 

### DIFF
--- a/src/inc/fmt.h
+++ b/src/inc/fmt.h
@@ -14,7 +14,7 @@
     uint32_t:  a "%"PRIu32 b ,                                                \
     uint64_t:  a "%"PRIu64 b ,                                                \
     void*:     a "%p"      b ,                                                \
-    default:   a "%x"      b                                                  \
+    default:   a "%p"      b                                                  \
 )
 
 

--- a/src/str/str.c
+++ b/src/str/str.c
@@ -37,6 +37,10 @@ err_return:
 int
 st_str_init_0(st_str_t *s, int64_t len) {
 
+    st_must(s != NULL, ST_ARG_INVALID);
+    st_must(len >= 0, ST_ARG_INVALID);
+    st_must(s->bytes_owned == 0, ST_INITTWICE);
+
     int ret = st_str_init(s, len + 1);
 
     if (ret != ST_OK) {
@@ -44,9 +48,8 @@ st_str_init_0(st_str_t *s, int64_t len) {
     }
 
     s->len = len;
-    s->bytes[s->len] = 0;
 
-    return ret;
+    return ST_OK;
 }
 
 
@@ -70,6 +73,7 @@ int
 st_str_ref(st_str_t *s, const st_str_t *target) {
     st_must(s != NULL, ST_ARG_INVALID);
     st_must(s->bytes_owned == 0, ST_INITTWICE);
+    st_must(s != target, ST_ARG_INVALID);
     st_must(target != NULL, ST_ARG_INVALID);
 
     int ret = ST_OK;
@@ -156,6 +160,20 @@ st_str_copy_cstr(st_str_t *str, const char *s) {
     return ST_OK;
 }
 
+int
+st_str_seize(st_str_t *str, st_str_t *from) {
+
+    st_must(str != NULL, ST_ARG_INVALID);
+    st_must(str->bytes_owned == 0, ST_INITTWICE);
+    st_must(from != NULL, ST_ARG_INVALID);
+    st_must(str != from, ST_ARG_INVALID);
+
+    *str = *from;
+    from->bytes_owned = 0;
+
+    return ST_OK;
+}
+
 /*
  * int st_str_to_str(const st_str_t *ptr, char *buf, const int64_t len, int64_t *pos) {
  *   st_must_be(ptr && ptr->inited_ && buf && len > 0 && pos, ST_ERR_INVALID_ARG);
@@ -167,7 +185,8 @@ st_str_copy_cstr(st_str_t *str, const char *s) {
  * }
  */
 
-int st_str_cmp(const st_str_t *a, const st_str_t *b) {
+int
+st_str_cmp(const st_str_t *a, const st_str_t *b) {
 
     st_must(a != NULL, ST_ARG_INVALID);
     st_must(b != NULL, ST_ARG_INVALID);

--- a/src/str/str.h
+++ b/src/str/str.h
@@ -38,6 +38,9 @@ static uint8_t *empty_str_ __attribute__((unused)) = (uint8_t*)"";
 #define st_str_empty              {.left=NULL, .len=0,           .capacity=1,            .bytes_owned=0, .bytes=(uint8_t*)empty_str_}
 
 #define st_str_equal(a, b)                                                    \
+        st_str_equal_((st_str_t*)(a), (st_str_t*)(b))
+
+#define st_str_equal_(a, b)                                                   \
   ((a) != NULL                                                                \
    && (b) != NULL                                                             \
    && (a)->bytes != NULL                                                      \
@@ -106,17 +109,8 @@ int st_str_copy_cstr(st_str_t *str, const char *s);
  */
 
 /* take ownership of bytes from another st_str_t 'from'. */
-static inline void st_str_seize(st_str_t *str, st_str_t *from) {
+int st_str_seize(st_str_t *str, st_str_t *from);
 
-  if (str == NULL || from == NULL || str == from) {
-    return;
-  }
-
-  st_str_destroy(str);
-
-  *str = *from;
-  from->bytes_owned = 0;
-}
 
 // thread_safe: no
 int st_str_cmp(const st_str_t *a, const st_str_t *b);

--- a/src/str/test_str.c
+++ b/src/str/test_str.c
@@ -1,18 +1,18 @@
 #include "str.h"
 #include "unittest/unittest.h"
 
-#define literal "abc"
+#define FOO "abc"
 
 st_test(str, const) {
 
     {
-        st_str_t s = st_str_const(literal);
+        st_str_t s = st_str_const(FOO);
 
-        st_ut_eq(NULL,              s.left,        "left is NULL");
-        st_ut_eq(sizeof(literal)-1, s.len,         "len");
-        st_ut_eq(sizeof(literal),   s.capacity,    "capacity");
-        st_ut_eq(0,                 s.bytes_owned, "bytes_owned is 0");
-        st_ut_ne(NULL,              s.bytes,       "bytes is not NULL");
+        st_ut_eq(NULL,          s.left,        "left is NULL");
+        st_ut_eq(sizeof(FOO)-1, s.len,         "len");
+        st_ut_eq(sizeof(FOO),   s.capacity,    "capacity");
+        st_ut_eq(0,             s.bytes_owned, "bytes_owned is 0");
+        st_ut_ne(NULL,          s.bytes,       "bytes is not NULL");
     }
 
     {
@@ -26,9 +26,9 @@ st_test(str, const) {
     }
 
     {
-        char *b = literal;
-        int64_t l = 2;
-        st_str_t s = st_str_wrap(b, l);
+        char     *b = FOO;
+        int64_t   l = 2;
+        st_str_t  s = st_str_wrap(b, l);
 
         st_ut_eq(NULL, s.left,        "left is NULL");
         st_ut_eq(l,    s.len,         "len");
@@ -38,9 +38,9 @@ st_test(str, const) {
     }
 
     {
-        char *b = literal;
-        int64_t l = sizeof(literal) - 1;
-        st_str_t s = st_str_wrap_0(b, l);
+        char     *b = FOO;
+        int64_t   l = sizeof(FOO) - 1;
+        st_str_t  s = st_str_wrap_0(b, l);
 
         st_ut_eq(NULL, s.left,        "left is NULL");
         st_ut_eq(l,    s.len,         "len");
@@ -86,8 +86,13 @@ st_test(str, const) {
 
 st_test(str, init_invalid) {
 
+    {
+        int ret = st_str_init(NULL, 1);
+        st_ut_eq(ST_ARG_INVALID, ret, "s is NULL");
+    }
+
     struct case_s {
-        uint64_t inp;
+        int64_t inp;
         int expected;
     } cases[] = {
         {-1, ST_ARG_INVALID},
@@ -147,7 +152,7 @@ st_test(str, init) {
 
         st_ut_eq(NULL, s.left,        "left is NULL");
         st_ut_eq(1,    s.len,         "len is 0");
-        st_ut_eq(1,    s.capacity,    "capacity is 1, because it use a pre-allocated empty c-string");
+        st_ut_eq(1,    s.capacity,    "capacity is 1");
         st_ut_eq(1,    s.bytes_owned, "bytes_owned is 1");
         st_ut_ne(NULL, s.bytes,       "bytes is not NULL");
 
@@ -171,14 +176,383 @@ st_test(str, init) {
     }
 }
 
-/* test init_0 invalid and valid */
-/* test equal */
-/* test n_arr */
-/* test trailing_0 */
-/* test destroy */
-/* test ref */
-/* test copy */
-/* test copy_cstr */
-/* test cmp */
-/* test seize */
+st_test(str, init_0) {
+
+    int ret;
+
+    {
+        st_str_t s = st_str_null;
+        ret = st_str_init_0(&s, 0);
+        st_ut_eq(ST_OK, ret, "init ok");
+
+        st_ut_eq(NULL, s.left,        "left is NULL");
+        st_ut_eq(0,    s.len,         "len is 0");
+        st_ut_eq(1,    s.capacity,    "capacity is 1, because it use a pre-allocated empty c-string");
+        st_ut_eq(1,    s.bytes_owned, "bytes_owned is 0, use pre-allocated empty c-string");
+        st_ut_ne(NULL, s.bytes,       "bytes is not NULL");
+
+        ret = st_str_destroy(&s);
+        st_ut_eq(ST_OK, ret, "destroy");
+    }
+
+    {
+        st_str_t s = st_str_null;
+        ret = st_str_init_0(&s, 1);
+        st_ut_eq(ST_OK, ret, "init ok");
+
+        st_ut_eq(NULL, s.left,        "left is NULL");
+        st_ut_eq(1,    s.len,         "len");
+        st_ut_eq(2,    s.capacity,    "capacity is 2");
+        st_ut_eq(1,    s.bytes_owned, "bytes_owned is 1");
+        st_ut_ne(NULL, s.bytes,       "bytes is not NULL");
+
+        ret = st_str_destroy(&s);
+        st_ut_eq(ST_OK, ret, "destroy");
+    }
+
+    {
+        st_str_t s = st_str_null;
+        ret = st_str_init_0(&s, 102400);
+        st_ut_eq(ST_OK, ret, "init ok");
+
+        st_ut_eq(NULL,   s.left,        "left is NULL");
+        st_ut_eq(102400, s.len,         "len");
+        st_ut_eq(102401, s.capacity,    "capacity");
+        st_ut_eq(1,      s.bytes_owned, "bytes_owned is 1");
+        st_ut_ne(NULL,   s.bytes,       "bytes is not NULL");
+
+        ret = st_str_destroy(&s);
+        st_ut_eq(ST_OK, ret, "destroy");
+    }
+}
+
+st_test(str, init_0_invalid) {
+
+    {
+        int ret = st_str_init_0(NULL, 1);
+        st_ut_eq(ST_ARG_INVALID, ret, "s is NULL");
+    }
+
+
+    struct case_s {
+        int64_t inp;
+        int expected;
+    } cases[] = {
+        {-1, ST_ARG_INVALID},
+        {-2, ST_ARG_INVALID},
+        {-1024, ST_ARG_INVALID},
+    };
+
+    for (int i = 0; i < st_nelts(cases); i++) {
+        st_typeof(cases[0])   c = cases[i];
+        st_typeof(c.expected) rst;
+
+        st_str_t s = {0};
+
+        rst = st_str_init_0(&s, c.inp);
+
+        st_ut_eq(c.expected, rst, "");
+
+        st_ut_eq(NULL, s.left,        "left is NULL");
+        st_ut_eq(NULL, s.right,       "right is NULL");
+        st_ut_eq(0,    s.len,         "len is 0");
+        st_ut_eq(0,    s.capacity,    "capacity is 0");
+        st_ut_eq(0,    s.bytes_owned, "bytes_owned is 0");
+        st_ut_eq(NULL, s.bytes,       "bytes is NULL");
+    }
+}
+
+st_test(str, equal) {
+
+    {
+        st_str_t *emp = &(st_str_t)st_str_empty;
+        st_str_t *nu = &(st_str_t)st_str_null;
+
+        st_ut_eq(0, st_str_equal(NULL, emp), "");
+        st_ut_eq(0, st_str_equal(emp, NULL), "");
+        st_ut_eq(0, st_str_equal(NULL, nu), "");
+        st_ut_eq(0, st_str_equal(nu, NULL), "");
+        st_ut_eq(0, st_str_equal(emp, nu), "");
+        st_ut_eq(0, st_str_equal(nu, emp), "");
+
+    }
+
+    struct case_s {
+        char *a;
+        char *b;
+        int expected;
+    } cases[] = {
+        {"",   "",   1},
+        {"",   "a",  0},
+        {"a",  "",   0},
+        {"a",  "a",  1},
+        {"aa", "a",  0},
+        {"a",  "aa", 0},
+        {"aa", "aa", 1},
+        {"ab", "aa", 0},
+        {"aa", "ab", 0},
+        {"ab", "ab", 1},
+    };
+
+    for (int i = 0; i < st_nelts(cases); i++) {
+        st_typeof(cases[0])   c = cases[i];
+        st_typeof(c.expected) rst;
+
+        st_str_t a = st_str_wrap(c.a, strlen(c.a));
+        st_str_t b = st_str_wrap(c.b, strlen(c.b));
+        rst = st_str_equal(&a, &b);
+
+        ddx(rst);
+
+        st_ut_eq(c.expected, rst, "");
+    }
+}
+
+st_test(str, cmp) {
+
+    {
+        st_str_t *emp = &(st_str_t)st_str_empty;
+        st_str_t *nu  = &(st_str_t)st_str_null;
+
+        st_ut_eq(ST_ARG_INVALID, st_str_cmp(NULL, NULL), "");
+        st_ut_eq(ST_ARG_INVALID, st_str_cmp(NULL, emp),  "");
+        st_ut_eq(ST_ARG_INVALID, st_str_cmp(emp,  NULL), "");
+
+        st_ut_eq(1,  st_str_cmp(emp, nu),  "");
+        st_ut_eq(0,  st_str_cmp(emp, emp), "");
+        st_ut_eq(-1, st_str_cmp(nu,  emp), "");
+    }
+
+    struct case_s {
+        char *a;
+        char *b;
+        int expected;
+    } cases[] = {
+        {"",   "",   0},
+        {"",   "a",  -1},
+        {"a",  "",   1},
+        {"a",  "a",  0},
+        {"aa", "a",  1},
+        {"a",  "aa", -1},
+        {"aa", "aa", 0},
+        {"ab", "aa", 1},
+        {"aa", "ab", -1},
+        {"ab", "ab", 0},
+    };
+
+    for (int i = 0; i < st_nelts(cases); i++) {
+        st_typeof(cases[0])   c = cases[i];
+        st_typeof(c.expected) rst;
+
+        st_str_t a = st_str_wrap(c.a, strlen(c.a));
+        st_str_t b = st_str_wrap(c.b, strlen(c.b));
+        rst = st_str_cmp(&a, &b);
+
+        ddx(rst);
+
+        st_ut_eq(c.expected, rst, "");
+    }
+}
+
+st_test(str, trailing_0) {
+
+    st_str_t s = st_str_const(FOO);
+    st_ut_eq(1, st_str_trailing_0(&s), "");
+
+    s.len += 1;
+    st_ut_eq(0, st_str_trailing_0(&s), "");
+
+    /* len = capacity-2, invalid str */
+    s.len -= 2;
+    st_ut_eq(0, st_str_trailing_0(&s), "");
+}
+
+st_test(str, destroy) {
+
+    {
+        st_ut_eq(ST_ARG_INVALID, st_str_destroy(NULL), "destroy NULL");
+    }
+
+    int ret;
+
+    st_str_t s = st_str_null;
+    ret = st_str_init(&s, 10);
+    st_ut_eq(ST_OK, ret, "init ok");
+
+    st_ut_eq(NULL, s.left,        "left is NULL");
+    st_ut_eq(10,   s.len,         "len is 10");
+    st_ut_eq(10,   s.capacity,    "capacity is 10");
+    st_ut_eq(1,    s.bytes_owned, "bytes_owned is 1");
+    st_ut_ne(NULL, s.bytes,       "bytes is not NULL");
+
+    ret = st_str_destroy(&s);
+    st_ut_eq(ST_OK, ret, "destroy");
+
+    st_ut_eq(NULL, s.left,        "left is NULL");
+    st_ut_eq(0,    s.len,         "len is 0");
+    st_ut_eq(0,    s.capacity,    "capacity is 0");
+    st_ut_eq(0,    s.bytes_owned, "bytes_owned is 0");
+    st_ut_eq(NULL, s.bytes,       "bytes is NULL");
+}
+
+st_test(str, ref) {
+
+    {
+        st_str_t s = st_str_null;
+        st_str_t t = st_str_null;
+
+        st_ut_eq(ST_ARG_INVALID, st_str_ref(NULL, NULL), "");
+        st_ut_eq(ST_ARG_INVALID, st_str_ref(NULL, &s), "");
+        st_ut_eq(ST_ARG_INVALID, st_str_ref(&s, NULL), "");
+        st_ut_eq(ST_ARG_INVALID, st_str_ref(&s, &s), "");
+
+        s.bytes_owned = 1;
+        st_ut_eq(ST_INITTWICE, st_str_ref(&s, &t), "");
+    }
+
+    int ret;
+
+    st_str_t s = st_str_null;
+    ret = st_str_init(&s, 10);
+    st_ut_eq(ST_OK, ret, "init ok");
+
+    st_str_t ref = st_str_null;
+
+    ret = st_str_ref(&ref, &s);
+    st_ut_eq(ST_OK, ret, "");
+
+    st_ut_eq(1, s.bytes_owned, "target bytes_owned does not change");
+
+    st_ut_eq(NULL,    ref.left,        "left is NULL");
+    st_ut_eq(10,      ref.len,         "len is 0");
+    st_ut_eq(10,      ref.capacity,    "capacity is 0");
+    st_ut_eq(0,       ref.bytes_owned, "bytes_owned is 0, ref does not need to free memory");
+    st_ut_eq(s.bytes, ref.bytes,       "bytes is shared");
+
+    ret = st_str_destroy(&s);
+    st_ut_eq(ST_OK, ret, "destroy s");
+
+    ret = st_str_destroy(&ref);
+    st_ut_eq(ST_OK, ret, "destroy ref");
+}
+
+st_test(str, copy) {
+
+    {
+        st_str_t s = st_str_null;
+        st_str_t t = st_str_null;
+
+        st_ut_eq(ST_ARG_INVALID, st_str_copy(NULL, NULL), "");
+        st_ut_eq(ST_ARG_INVALID, st_str_copy(NULL, &s), "");
+        st_ut_eq(ST_ARG_INVALID, st_str_copy(&s, NULL), "");
+        st_ut_eq(ST_ARG_INVALID, st_str_copy(&s, &s), "");
+
+        s.bytes_owned = 1;
+        st_ut_eq(ST_INITTWICE, st_str_ref(&s, &t), "");
+    }
+
+    int ret;
+
+    st_str_t s = st_str_null;
+    ret = st_str_init_0(&s, 10);
+    st_ut_eq(ST_OK, ret, "init ok");
+
+    st_str_t cpy = st_str_null;
+
+    ret = st_str_copy(&cpy, &s);
+    st_ut_eq(ST_OK, ret, "");
+
+    st_ut_eq(1, s.bytes_owned, "target bytes_owned does not change");
+
+    st_ut_eq(NULL,       cpy.left,        "left is NULL");
+    st_ut_eq(s.len,      cpy.len,         "len is same as s");
+    st_ut_eq(s.capacity, cpy.capacity,    "capacity is same as s");
+    st_ut_eq(1,          cpy.bytes_owned, "bytes_owned is 1, memory reallocated");
+    st_ut_ne(s.bytes,    cpy.bytes,       "bytes is not shared");
+
+    ret = st_memcmp(s.bytes, cpy.bytes, s.capacity);
+    st_ut_eq(0, ret, "cpy.bytes is same as s.bytes");
+
+    ret = st_str_destroy(&s);
+    st_ut_eq(ST_OK, ret, "destroy s");
+
+    ret = st_str_destroy(&cpy);
+    st_ut_eq(ST_OK, ret, "destroy cpy");
+}
+
+st_test(str, copy_cstr) {
+
+    {
+        st_str_t s = st_str_null;
+
+        st_ut_eq(ST_ARG_INVALID, st_str_copy_cstr(NULL, NULL), "");
+        st_ut_eq(ST_ARG_INVALID, st_str_copy_cstr(NULL, FOO), "");
+        st_ut_eq(ST_ARG_INVALID, st_str_copy_cstr(&s, NULL), "");
+
+        s.bytes_owned = 1;
+        st_ut_eq(ST_INITTWICE, st_str_copy_cstr(&s, FOO), "");
+    }
+
+    int ret;
+
+    st_str_t s = st_str_null;
+
+    ret = st_str_copy_cstr(&s, FOO);
+    st_ut_eq(ST_OK, ret, "");
+
+    st_ut_eq(NULL,          s.left,        "left is NULL");
+    st_ut_eq(sizeof(FOO)-1, s.len,         "len is strlen(FOO)");
+    st_ut_eq(sizeof(FOO),   s.capacity,    "capacity is sizeof(FOO)");
+    st_ut_eq(1,             s.bytes_owned, "bytes_owned is 1, memory allocated");
+    st_ut_ne(NULL,          s.bytes,       "bytes is not NULL");
+
+    ret = st_memcmp(FOO, s.bytes, s.capacity);
+    st_ut_eq(0, ret, "s.bytes is same as FOO");
+
+    ret = st_str_destroy(&s);
+    st_ut_eq(ST_OK, ret, "destroy s");
+}
+
+st_test(str, seize) {
+
+    {
+        st_str_t s = st_str_null;
+        st_str_t t = st_str_null;
+
+        st_ut_eq(ST_ARG_INVALID, st_str_seize(NULL, NULL), "");
+        st_ut_eq(ST_ARG_INVALID, st_str_seize(NULL, &s), "");
+        st_ut_eq(ST_ARG_INVALID, st_str_seize(&s, NULL), "");
+        st_ut_eq(ST_ARG_INVALID, st_str_seize(&s, &s), "");
+
+        s.bytes_owned = 1;
+        st_ut_eq(ST_INITTWICE, st_str_ref(&s, &t), "");
+    }
+
+    int ret;
+
+    st_str_t s = st_str_null;
+    ret = st_str_init_0(&s, 10);
+    st_ut_eq(ST_OK, ret, "init ok");
+
+    st_str_t seize = st_str_null;
+
+    ret = st_str_seize(&seize, &s);
+    st_ut_eq(ST_OK, ret, "");
+
+    st_ut_eq(0, s.bytes_owned, "target bytes_owned does not change");
+
+    st_ut_eq(s.left,     seize.left,        "left is NULL");
+    st_ut_eq(s.len,      seize.len,         "len is same as s");
+    st_ut_eq(s.capacity, seize.capacity,    "capacity is same as s");
+    st_ut_eq(1,          seize.bytes_owned, "bytes_owned is 1");
+    st_ut_eq(s.bytes,    seize.bytes,       "bytes is copied");
+
+    ret = st_str_destroy(&s);
+    st_ut_eq(ST_OK, ret, "destroy s");
+
+    ret = st_str_destroy(&seize);
+    st_ut_eq(ST_OK, ret, "destroy seize");
+}
+
+/* TODO test n_arr */
 st_ut_main;

--- a/src/unittest/unittest.h
+++ b/src/unittest/unittest.h
@@ -203,15 +203,16 @@ st_ut_run_bench(st_ut_bench_t *b) {
 #define st_ut_compare(a, b) st_ut_norm_cmp(a, b)
 
 #define st_ut_print_func_(v) _Generic((v),                                    \
-        char               : st_print_char        ,                           \
-        int                : st_print_int         ,                           \
-        long               : st_print_long        ,                           \
-        long long          : st_print_longlong    ,                           \
+                 char      : st_print_char        ,                           \
+                 int       : st_print_int         ,                           \
+                 long      : st_print_long        ,                           \
+                 long long : st_print_longlong    ,                           \
+        unsigned char      : st_print_uchar       ,                           \
         unsigned int       : st_print_uint        ,                           \
         unsigned long      : st_print_ulong       ,                           \
         unsigned long long : st_print_ulonglong   ,                           \
-        void*              : st_print_void_ptr    ,                           \
-        default            : st_print_void_ptr                                \
+                 void*     : st_print_void_ptr    ,                           \
+                 default   : st_print_void_ptr                                \
 )
 
 
@@ -231,6 +232,7 @@ static inline char *st_print_char      (char               a) { st_ut_print_("%c
 static inline char *st_print_int       (int                a) { st_ut_print_("%d",   a); }
 static inline char *st_print_long      (long               a) { st_ut_print_("%ld",  a); }
 static inline char *st_print_longlong  (long long          a) { st_ut_print_("%lld", a); }
+static inline char *st_print_uchar     (unsigned char      a) { st_ut_print_("%u",   a); }
 static inline char *st_print_uint      (unsigned int       a) { st_ut_print_("%u",   a); }
 static inline char *st_print_ulong     (unsigned long      a) { st_ut_print_("%lu",  a); }
 static inline char *st_print_ulonglong (unsigned long long a) { st_ut_print_("%llu", a); }


### PR DESCRIPTION
-   `st_str_ref`: 引用另一个str,但不持有对方的内存.
-   `st_str_equal`: 判断是否相等,支持NULL作为参数.
-   `st_str_trailing_0`: 判断是否str内存中保存了`\0`结束符.
-   `st_str_destroy`: 销毁属于自己的内存.
-   `st_str_copy`: 复制str, 分配新内存保存copy的结果.
-   `st_str_copy_cstr`: 从1个`char*`的string复制.
-   `st_str_cmp`: 比较大小,返回 `-1, 0, 1`.
-   `st_str_seize`: 将另1个str的内存占位己有, 之后自己负责内存释放,另1个str不再负责释放内存.

fix: #1 