### PR TITLE
add refcnt module

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@
 BASE_DIR := $(CURDIR)
 export BASE_DIR
 
-submod = binary btree robustlock list rbtree array bitmap atomic region pagepool slab
+submod = binary btree robustlock list rbtree array bitmap atomic region pagepool slab refcnt
 
 test:
 	for mod in $(submod); do ( cd $$mod && $(MAKE) test; ) done

--- a/src/inc/callback.h
+++ b/src/inc/callback.h
@@ -6,6 +6,9 @@ typedef void * (*st_callback_realloc_f) (void *pool, void *ptr, size_t size);
 typedef void * (*st_callback_calloc_f) (void *pool, size_t nmemb, size_t size);
 typedef void (*st_callback_free_f) (void *pool, void *ptr);
 
+typedef int (*st_callback_alloc_with_ret_f) (void *pool, size_t size, void **ptr);
+typedef int (*st_callback_free_with_ret_f) (void *pool, void *ptr);
+
 typedef struct st_callback_memory_s st_callback_memory_t;
 
 struct st_callback_memory_s {
@@ -15,6 +18,9 @@ struct st_callback_memory_s {
     st_callback_realloc_f realloc;
     st_callback_calloc_f calloc;
     st_callback_free_f free;
+
+    st_callback_alloc_with_ret_f alloc_with_ret;
+    st_callback_free_with_ret_f free_with_ret;
 };
 
 #endif /* _CALLBACK_H_INCLUDED_ */

--- a/src/pagepool/test_pagepool.c
+++ b/src/pagepool/test_pagepool.c
@@ -1,5 +1,3 @@
-#define ST_UNIT_TEST
-
 #include "pagepool.h"
 #include "unittest/unittest.h"
 #include <sys/mman.h>

--- a/src/refcnt/Makefile
+++ b/src/refcnt/Makefile
@@ -1,0 +1,9 @@
+
+src       = refcnt.c
+target    = refcnt.a
+test_exec = test_refcnt
+deps      = robustlock rbtree
+libs      = rt pthread
+
+BASE_DIR ?= $(CURDIR)/..
+include $(BASE_DIR)/def.mk

--- a/src/refcnt/refcnt.c
+++ b/src/refcnt/refcnt.c
@@ -1,0 +1,228 @@
+#include "refcnt.h"
+
+static int st_refcnt_cmp_process(st_rbtree_node_t *a, st_rbtree_node_t *b) {
+    st_refcnt_process_t *pa = st_owner(a, st_refcnt_process_t, rbnode);
+    st_refcnt_process_t *pb = st_owner(b, st_refcnt_process_t, rbnode);
+
+    return st_cmp(pa->pid, pb->pid);
+}
+
+static int st_refcnt_new_process(st_refcnt_t *refcnt, pid_t pid, st_refcnt_process_t **process) {
+
+    st_refcnt_process_t *tmp = NULL;
+    st_callback_memory_t *cb = &refcnt->callback;
+
+    int ret = cb->alloc_with_ret(cb->pool, sizeof(st_refcnt_process_t), (void **)&tmp);
+    if (ret != ST_OK) {
+        return ret;
+    }
+
+    *tmp = (st_refcnt_process_t){
+        .rbnode = (st_rbtree_node_t)st_rbtree_node_empty,
+        .pid = pid,
+        .cnt = 0,
+    };
+
+    *process = tmp;
+
+    return ST_OK;
+}
+
+static int st_refcnt_release_process(st_refcnt_t *refcnt, st_refcnt_process_t *process) {
+    st_callback_memory_t *cb = &refcnt->callback;
+
+    return cb->free_with_ret(cb->pool, process);
+}
+
+static int st_refcnt_get_process(st_refcnt_t *refcnt, pid_t pid, st_refcnt_process_t **process) {
+
+    st_refcnt_process_t tmp = {.pid = pid};
+
+    st_rbtree_node_t *n = st_rbtree_search_eq(&refcnt->processes, &tmp.rbnode);
+    if (n == NULL) {
+        return ST_NOT_FOUND;
+    }
+
+    *process = st_owner(n, st_refcnt_process_t, rbnode);
+
+    return ST_OK;
+}
+
+int st_refcnt_init(st_refcnt_t *refcnt, st_callback_memory_t callback) {
+    st_must(refcnt != NULL, ST_ARG_INVALID);
+    st_must(callback.alloc_with_ret != NULL, ST_ARG_INVALID);
+    st_must(callback.free_with_ret != NULL, ST_ARG_INVALID);
+
+    int ret = st_rbtree_init(&refcnt->processes, st_refcnt_cmp_process);
+    if (ret != ST_OK) {
+        return ret;
+    }
+
+    ret = st_robustlock_init(&refcnt->lock);
+    if (ret != ST_OK) {
+        return ret;
+    }
+
+    refcnt->callback = callback;
+    refcnt->total_cnt = 0;
+
+    return ret;
+}
+
+int st_refcnt_destroy(st_refcnt_t *refcnt) {
+    st_must(refcnt != NULL, ST_ARG_INVALID);
+
+    int ret;
+    st_rbtree_node_t *n = NULL;
+    st_refcnt_process_t *process = NULL;
+
+    while (!st_rbtree_is_empty(&refcnt->processes)) {
+
+        n = st_rbtree_left_most(&refcnt->processes);
+
+        st_rbtree_delete(&refcnt->processes, n);
+
+        process = st_owner(n, st_refcnt_process_t, rbnode);
+
+        ret = st_refcnt_release_process(refcnt, process);
+        if (ret != ST_OK) {
+            return ret;
+        }
+    }
+
+    ret = st_robustlock_destroy(&refcnt->lock);
+    if (ret != ST_OK) {
+        return ret;
+    }
+
+    refcnt->total_cnt = 0;
+
+    return ret;
+}
+
+int st_refcnt_get_process_refcnt(st_refcnt_t *refcnt, pid_t pid, int64_t *cnt) {
+
+    st_must(refcnt != NULL, ST_ARG_INVALID);
+    st_must(cnt != NULL, ST_ARG_INVALID);
+
+    st_refcnt_process_t *process = NULL;
+
+    int ret = st_robustlock_lock(&refcnt->lock);
+    if (ret != ST_OK) {
+        return ret;
+    }
+
+    ret = st_refcnt_get_process(refcnt, pid, &process);
+    if (ret != ST_OK) {
+        goto quit;
+    }
+
+    *cnt = process->cnt;
+
+quit:
+    st_robustlock_unlock_err_abort(&refcnt->lock);
+    return ret;
+}
+
+int st_refcnt_get_total_refcnt(st_refcnt_t *refcnt, int64_t *cnt) {
+
+    st_must(refcnt != NULL, ST_ARG_INVALID);
+    st_must(cnt != NULL, ST_ARG_INVALID);
+
+    int ret = st_robustlock_lock(&refcnt->lock);
+    if (ret != ST_OK) {
+        return ret;
+    }
+
+    *cnt = refcnt->total_cnt;
+
+    st_robustlock_unlock_err_abort(&refcnt->lock);
+    return ret;
+}
+
+int st_refcnt_incr(st_refcnt_t *refcnt, pid_t pid, int64_t cnt, int64_t *process_refcnt,
+                   int64_t *total_refcnt) {
+
+    st_must(refcnt != NULL, ST_ARG_INVALID);
+
+    st_refcnt_process_t *process = NULL;
+
+    int ret = st_robustlock_lock(&refcnt->lock);
+    if (ret != ST_OK) {
+        return ret;
+    }
+
+    ret = st_refcnt_get_process(refcnt, pid, &process);
+
+    if (ret == ST_NOT_FOUND) {
+
+        ret = st_refcnt_new_process(refcnt, pid, &process);
+        if (ret != ST_OK) {
+            goto quit;
+        }
+
+        st_rbtree_insert(&refcnt->processes, &process->rbnode);
+
+    } else if (ret != ST_OK) {
+        goto quit;
+    }
+
+    process->cnt += cnt;
+    refcnt->total_cnt += cnt;
+
+    if (process_refcnt != NULL) {
+        *process_refcnt = process->cnt;
+    }
+
+    if (total_refcnt != NULL) {
+        *total_refcnt = refcnt->total_cnt;
+    }
+
+quit:
+    st_robustlock_unlock_err_abort(&refcnt->lock);
+    return ret;
+}
+
+int st_refcnt_decr(st_refcnt_t *refcnt, pid_t pid, int64_t cnt, int64_t *process_refcnt,
+                   int64_t *total_refcnt) {
+
+    st_must(refcnt != NULL, ST_ARG_INVALID);
+
+    st_refcnt_process_t *process = NULL;
+
+    int ret = st_robustlock_lock(&refcnt->lock);
+    if (ret != ST_OK) {
+        return ret;
+    }
+
+    ret = st_refcnt_get_process(refcnt, pid, &process);
+    if (ret != ST_OK) {
+        goto quit;
+    }
+
+    if (cnt > process->cnt) {
+        ret = ST_OUT_OF_RANGE;
+        goto quit;
+    }
+
+    process->cnt -= cnt;
+    refcnt->total_cnt -= cnt;
+
+    if (process_refcnt != NULL) {
+        *process_refcnt = process->cnt;
+    }
+
+    if (total_refcnt != NULL) {
+        *total_refcnt = refcnt->total_cnt;
+    }
+
+    if (process->cnt == 0) {
+        st_rbtree_delete(&refcnt->processes, &process->rbnode);
+
+        ret = st_refcnt_release_process(refcnt, process);
+    }
+
+quit:
+    st_robustlock_unlock_err_abort(&refcnt->lock);
+    return ret;
+}

--- a/src/refcnt/refcnt.h
+++ b/src/refcnt/refcnt.h
@@ -1,0 +1,60 @@
+#ifndef _REFCNT_H_INCLUDED_
+#define _REFCNT_H_INCLUDED_
+
+#include <stdint.h>
+#include <string.h>
+
+#include "inc/err.h"
+#include "inc/log.h"
+#include "inc/util.h"
+#include "inc/callback.h"
+#include "rbtree/rbtree.h"
+#include "robustlock/robustlock.h"
+
+typedef struct st_refcnt_process_s st_refcnt_process_t;
+typedef struct st_refcnt_s st_refcnt_t;
+
+/**
+ * each process refcnt
+ */
+struct st_refcnt_process_s {
+    /* each process refcnt */
+    int64_t cnt;
+
+    /* process id as rbtree node key*/
+    pid_t pid;
+
+    st_rbtree_node_t rbnode;
+};
+
+/**
+ * all processes refcnt
+ */
+struct st_refcnt_s {
+    /* used to alloc or free st_refcnt_process_t struct memory space */
+    st_callback_memory_t callback;
+
+    /* all processes refcnt sum */
+    int total_cnt;
+
+    /* all processes in rbtree */
+    st_rbtree_t processes;
+
+    pthread_mutex_t lock;
+};
+
+int st_refcnt_init(st_refcnt_t *refcnt, st_callback_memory_t callback);
+
+int st_refcnt_destroy(st_refcnt_t *refcnt);
+
+int st_refcnt_get_process_refcnt(st_refcnt_t *refcnt, pid_t pid, int64_t *cnt);
+
+int st_refcnt_get_total_refcnt(st_refcnt_t *refcnt, int64_t *cnt);
+
+int st_refcnt_incr(st_refcnt_t *refcnt, pid_t pid, int64_t cnt, int64_t *process_refcnt,
+                   int64_t *total_refcnt);
+
+int st_refcnt_decr(st_refcnt_t *refcnt, pid_t pid, int64_t cnt, int64_t *process_refcnt,
+                   int64_t *total_refcnt);
+
+#endif /* _REFCNT_H_INCLUDED_ */

--- a/src/refcnt/test_refcnt.c
+++ b/src/refcnt/test_refcnt.c
@@ -1,0 +1,158 @@
+#include <stdlib.h>
+#include "refcnt.h"
+#include "unittest/unittest.h"
+
+#define test_callback_inited {.pool = NULL,\
+                              .alloc_with_ret = _alloc,\
+                              .free_with_ret = _free,}
+
+int _alloc(void *pool, size_t size, void **ptr) {
+    *ptr = malloc(size);
+    return ST_OK;
+}
+
+int _free(void *pool, void *ptr) {
+    free(ptr);
+    return ST_OK;
+}
+
+st_test(refcnt, init) {
+
+    st_refcnt_t refcnt;
+    st_callback_memory_t callback = test_callback_inited;
+
+    st_ut_eq(ST_OK, st_refcnt_init(&refcnt, callback), "");
+    st_ut_eq(0, memcmp(&refcnt.callback, &callback, sizeof(callback)), "");
+    st_ut_eq(refcnt.total_cnt, 0, "");
+
+    st_ut_eq(ST_ARG_INVALID, st_refcnt_init(NULL, callback), "");
+    st_ut_eq(ST_ARG_INVALID, st_refcnt_init(&refcnt, (st_callback_memory_t) {.alloc_with_ret = NULL}),
+    "");
+    st_ut_eq(ST_ARG_INVALID, st_refcnt_init(&refcnt, (st_callback_memory_t) {.alloc_with_ret = _alloc}),
+    "");
+}
+
+st_test(refcnt, destroy) {
+    st_refcnt_t refcnt;
+    st_callback_memory_t callback = test_callback_inited;
+    st_refcnt_init(&refcnt, callback);
+
+    st_refcnt_incr(&refcnt, getpid(), 2, NULL, NULL);
+    st_refcnt_incr(&refcnt, getpid() + 1, 3, NULL, NULL);
+
+    st_ut_eq(0, st_rbtree_is_empty(&refcnt.processes), "");
+    st_ut_eq(5, refcnt.total_cnt, "");
+
+    st_ut_eq(ST_OK, st_refcnt_destroy(&refcnt), "");
+
+    st_ut_eq(1, st_rbtree_is_empty(&refcnt.processes), "");
+    st_ut_eq(0, refcnt.total_cnt, "");
+}
+
+st_test(refcnt, incr_with_get) {
+
+    int ret;
+    st_refcnt_t refcnt;
+    int64_t process_refcnt;
+    int64_t total_refcnt;
+
+    st_callback_memory_t callback = test_callback_inited;
+    st_refcnt_init(&refcnt, callback);
+
+    struct case_s {
+        int64_t cnt;
+        int64_t process_refcnt;
+        int64_t total_refcnt;
+        pid_t pid;
+    } cases[] = {
+        {1, 1, 1, 1234},
+        {2, 2, 3, 2345},
+        {2, 3, 5, 1234},
+        {5, 5, 10, 3456},
+        {5, 7, 15, 2345},
+    };
+
+    for (int i = 0; i < st_nelts(cases); i++) {
+        st_typeof(cases[0]) c = cases[i];
+
+        ret = st_refcnt_incr(&refcnt, c.pid, c.cnt, &process_refcnt, &total_refcnt);
+        st_ut_eq(ST_OK, ret, "");
+        st_ut_eq(c.process_refcnt, process_refcnt, "");
+        st_ut_eq(c.total_refcnt, total_refcnt, "");
+
+        ret = st_refcnt_get_process_refcnt(&refcnt, c.pid, &process_refcnt);
+        st_ut_eq(ST_OK, ret, "");
+        st_ut_eq(c.process_refcnt, process_refcnt, "");
+
+        ret = st_refcnt_get_total_refcnt(&refcnt, &total_refcnt);
+        st_ut_eq(ST_OK, ret, "");
+        st_ut_eq(c.total_refcnt, total_refcnt, "");
+    }
+
+    st_ut_eq(ST_ARG_INVALID, st_refcnt_incr(NULL, getpid(), 1, &process_refcnt, &total_refcnt), "");
+
+    st_refcnt_destroy(&refcnt);
+}
+
+st_test(refcnt, decr_with_get) {
+
+    int ret;
+    st_refcnt_t refcnt;
+    int64_t process_refcnt;
+    int64_t total_refcnt;
+
+    st_callback_memory_t callback = test_callback_inited;
+    st_refcnt_init(&refcnt, callback);
+
+    st_refcnt_incr(&refcnt, 1234, 10, NULL, NULL);
+    st_refcnt_incr(&refcnt, 2345, 10, NULL, NULL);
+    st_refcnt_incr(&refcnt, 3456, 10, NULL, NULL);
+
+    struct case_s {
+        int64_t cnt;
+        int64_t process_refcnt;
+        int64_t total_refcnt;
+        pid_t pid;
+        int expect_ret;
+    } cases[] = {
+        {1, 9, 29, 1234, ST_OK},
+        {2, 8, 27, 2345, ST_OK},
+        {2, 7, 25, 1234, ST_OK},
+        {5, 5, 20, 3456, ST_OK},
+        {5, 3, 15, 2345, ST_OK},
+        {7, 0, 8, 1234, ST_OK},
+        {6, 3, 8, 2345, ST_OUT_OF_RANGE},
+        {3, 0, 5, 2345, ST_OK},
+        {5, 0, 0, 3456, ST_OK},
+        {5, 0, 0, 4567, ST_NOT_FOUND},
+    };
+
+    for (int i = 0; i < st_nelts(cases); i++) {
+        st_typeof(cases[0]) c = cases[i];
+
+        ret = st_refcnt_decr(&refcnt, c.pid, c.cnt, &process_refcnt, &total_refcnt);
+        st_ut_eq(c.expect_ret, ret, "");
+
+        if (c.expect_ret != ST_OK) {
+            continue;
+        }
+
+        st_ut_eq(c.process_refcnt, process_refcnt, "");
+        st_ut_eq(c.total_refcnt, total_refcnt, "");
+
+        if (process_refcnt == 0) {
+            st_ut_eq(ST_NOT_FOUND, st_refcnt_get_process_refcnt(&refcnt, c.pid, &process_refcnt), "");
+        } else {
+            st_ut_eq(ST_OK, st_refcnt_get_process_refcnt(&refcnt, c.pid, &process_refcnt), "");
+            st_ut_eq(c.process_refcnt, process_refcnt, "");
+        }
+
+        st_ut_eq(ST_OK, st_refcnt_get_total_refcnt(&refcnt, &total_refcnt), "");
+        st_ut_eq(c.total_refcnt, total_refcnt, "");
+    }
+
+    st_ut_eq(1, st_rbtree_is_empty(&refcnt.processes), "");
+    st_ut_eq(0, refcnt.total_cnt, "");
+}
+
+st_ut_main;


### PR DESCRIPTION
添加引用计数模块，
除了有总得引用计数，可以标识每个进程的引用次数。
当某个进程死了，需要清理这个进程持有的引用计数，可以通过该模块得到进程的引用计数。