### PR TITLE
add types in types.h and adjust str accordingly

### DIFF
--- a/src/inc/types.h
+++ b/src/inc/types.h
@@ -1,13 +1,20 @@
 #ifndef __ST_INC_TYPES_INCLUDE__
 #define __ST_INC_TYPES_INCLUDE__
 
-typedef enum st_types_e {
-    ST_TYPES_UNKNOWN = -1,
+typedef unsigned char st_bool;
 
-    ST_TYPES_STRING  = 0x00,
-    ST_TYPES_BOOLEAN = 0x01,
-    ST_TYPES_NUMBER  = 0x02,
-    ST_TYPES_TABLE   = 0x03,
+/** keep types value compatible with luajit-2.1 */
+typedef enum st_types_e {
+    ST_TYPES_UNKNOWN    = -1,
+
+    ST_TYPES_NIL        = 0x00,
+    ST_TYPES_BOOLEAN    = 0x01,
+    ST_TYPES_NUMBER     = 0x03,
+    ST_TYPES_INTEGER    = 0x13,
+    ST_TYPES_U64        = 0x23,
+    ST_TYPES_STRING     = 0x04,
+    ST_TYPES_CHAR_ARRAY = 0x14,
+    ST_TYPES_TABLE      = 0x17,
 
 } st_types_t;
 

--- a/src/str/str.h
+++ b/src/str/str.h
@@ -39,14 +39,14 @@ struct st_MemPool;
 static uint8_t *empty_str_ __attribute__((unused)) = (uint8_t *)"";
 
 #define st_str_wrap_common(_charptr, t, _len) {.type=t, .len=(_len), .capacity=(_len), .bytes_owned=0, .bytes=(uint8_t*)(_charptr)}
-#define st_str_wrap(_charptr, _len)           st_str_wrap_common(_charptr, 0, _len)
+#define st_str_wrap(_charptr, _len)           st_str_wrap_common(_charptr, ST_TYPES_STRING, _len)
 
-#define st_str_const(s)               {.type=0, .len=sizeof(s)-1,    .capacity=sizeof(s),      .bytes_owned=0, .bytes=(uint8_t*)(s)}
-#define st_str_var(_len)              {.type=0, .len=(_len),         .capacity=(_len),         .bytes_owned=0, .bytes=(uint8_t*)((char[_len]){0})}
-#define st_str_wrap_0(_charptr, _len) {.type=0, .len=(_len),         .capacity=(_len) + 1,     .bytes_owned=0, .bytes=(uint8_t*)(_charptr)}
-#define st_str_wrap_chars(_chars)     {.type=0, .len=sizeof(_chars), .capacity=sizeof(_chars), .bytes_owned=0, .bytes=(uint8_t*)(_chars)}
-#define st_str_null                   {.type=0, .len=0,              .capacity=0,              .bytes_owned=0, .bytes=NULL}
-#define st_str_empty                  {.type=0, .len=0,              .capacity=1,              .bytes_owned=0, .bytes=(uint8_t*)empty_str_}
+#define st_str_const(s)               {.type=ST_TYPES_STRING, .len=sizeof(s)-1,    .capacity=sizeof(s),      .bytes_owned=0, .bytes=(uint8_t*)(s)}
+#define st_str_var(_len)              {.type=ST_TYPES_STRING, .len=(_len),         .capacity=(_len),         .bytes_owned=0, .bytes=(uint8_t*)((char[_len]){0})}
+#define st_str_wrap_0(_charptr, _len) {.type=ST_TYPES_STRING, .len=(_len),         .capacity=(_len) + 1,     .bytes_owned=0, .bytes=(uint8_t*)(_charptr)}
+#define st_str_wrap_chars(_chars)     {.type=ST_TYPES_STRING, .len=sizeof(_chars), .capacity=sizeof(_chars), .bytes_owned=0, .bytes=(uint8_t*)(_chars)}
+#define st_str_null                   {.type=ST_TYPES_STRING, .len=0,              .capacity=0,              .bytes_owned=0, .bytes=NULL}
+#define st_str_empty                  {.type=ST_TYPES_STRING, .len=0,              .capacity=1,              .bytes_owned=0, .bytes=(uint8_t*)empty_str_}
 
 #define st_str_equal(a, b)                                                    \
         st_str_equal_((st_str_t*)(a), (st_str_t*)(b))

--- a/src/str/test_str.c
+++ b/src/str/test_str.c
@@ -1,5 +1,7 @@
 #include "str.h"
 #include "unittest/unittest.h"
+#include <limits.h>
+#include <float.h>
 
 #define FOO "abc"
 
@@ -8,21 +10,21 @@ st_test(str, const) {
     {
         st_str_t s = st_str_const(FOO);
 
-        st_ut_eq(0,             s.type,        "type is 0");
-        st_ut_eq(sizeof(FOO)-1, s.len,         "len");
-        st_ut_eq(sizeof(FOO),   s.capacity,    "capacity");
-        st_ut_eq(0,             s.bytes_owned, "bytes_owned is 0");
-        st_ut_ne(NULL,          s.bytes,       "bytes is not NULL");
+        st_ut_eq(ST_TYPES_STRING, s.type,        "type is not string");
+        st_ut_eq(sizeof(FOO)-1,   s.len,         "len");
+        st_ut_eq(sizeof(FOO),     s.capacity,    "capacity");
+        st_ut_eq(0,               s.bytes_owned, "bytes_owned is 0");
+        st_ut_ne(NULL,            s.bytes,       "bytes is not NULL");
     }
 
     {
         st_str_t s = st_str_var(10);
 
-        st_ut_eq(0,    s.type,        "type is 0");
-        st_ut_eq(10,   s.len,         "len");
-        st_ut_eq(10,   s.capacity,    "capacity");
-        st_ut_eq(0,    s.bytes_owned, "bytes_owned is 0");
-        st_ut_ne(NULL, s.bytes,       "bytes is not NULL");
+        st_ut_eq(ST_TYPES_STRING, s.type,        "type is not string");
+        st_ut_eq(10,              s.len,         "len");
+        st_ut_eq(10,              s.capacity,    "capacity");
+        st_ut_eq(0,               s.bytes_owned, "bytes_owned is 0");
+        st_ut_ne(NULL,            s.bytes,       "bytes is not NULL");
     }
 
     {
@@ -30,11 +32,11 @@ st_test(str, const) {
         int64_t   l = 2;
         st_str_t  s = st_str_wrap(b, l);
 
-        st_ut_eq(0,    s.type,        "type is 0");
-        st_ut_eq(l,    s.len,         "len");
-        st_ut_eq(l,    s.capacity,    "capacity");
-        st_ut_eq(0,    s.bytes_owned, "bytes_owned is 0");
-        st_ut_eq(b,    s.bytes,       "bytes is not NULL");
+        st_ut_eq(ST_TYPES_STRING, s.type,        "type is not string");
+        st_ut_eq(l,               s.len,         "len");
+        st_ut_eq(l,               s.capacity,    "capacity");
+        st_ut_eq(0,               s.bytes_owned, "bytes_owned is 0");
+        st_ut_eq(b,               s.bytes,       "bytes is not NULL");
     }
 
     {
@@ -42,11 +44,11 @@ st_test(str, const) {
         int64_t   l = sizeof(FOO) - 1;
         st_str_t  s = st_str_wrap_0(b, l);
 
-        st_ut_eq(0,    s.type,        "type is 0");
-        st_ut_eq(l,    s.len,         "len");
-        st_ut_eq(l+1,  s.capacity,    "capacity");
-        st_ut_eq(0,    s.bytes_owned, "bytes_owned is 0");
-        st_ut_eq(b,    s.bytes,       "bytes is b");
+        st_ut_eq(ST_TYPES_STRING, s.type,        "type is not string");
+        st_ut_eq(l,               s.len,         "len");
+        st_ut_eq(l+1,             s.capacity,    "capacity");
+        st_ut_eq(0,               s.bytes_owned, "bytes_owned is 0");
+        st_ut_eq(b,               s.bytes,       "bytes is b");
 
         st_ut_eq(1, st_str_trailing_0(&s), "it has trailing 0");
     }
@@ -55,31 +57,31 @@ st_test(str, const) {
         char b[10];
         st_str_t s = st_str_wrap_chars(b);
 
-        st_ut_eq(0,           s.type,        "type is 0");
-        st_ut_eq(10,          s.len,         "len");
-        st_ut_eq(10,          s.capacity,    "capacity");
-        st_ut_eq(0,           s.bytes_owned, "bytes_owned is 0");
-        st_ut_eq((uint8_t*)b, s.bytes,       "bytes is b");
+        st_ut_eq(ST_TYPES_STRING, s.type,        "type is not string");
+        st_ut_eq(10,              s.len,         "len");
+        st_ut_eq(10,              s.capacity,    "capacity");
+        st_ut_eq(0,               s.bytes_owned, "bytes_owned is 0");
+        st_ut_eq((uint8_t*)b,     s.bytes,       "bytes is b");
     }
 
     {
         st_str_t s = st_str_null;
 
-        st_ut_eq(0,    s.type,        "type is 0");
-        st_ut_eq(0,    s.len,         "len");
-        st_ut_eq(0,    s.capacity,    "capacity");
-        st_ut_eq(0,    s.bytes_owned, "bytes_owned is 0");
-        st_ut_eq(NULL, s.bytes,       "bytes is NULL");
+        st_ut_eq(ST_TYPES_STRING, s.type,        "type is not string");
+        st_ut_eq(0,               s.len,         "len");
+        st_ut_eq(0,               s.capacity,    "capacity");
+        st_ut_eq(0,               s.bytes_owned, "bytes_owned is 0");
+        st_ut_eq(NULL,            s.bytes,       "bytes is NULL");
     }
 
     {
         st_str_t s = st_str_empty;
 
-        st_ut_eq(0,    s.type,        "type is 0");
-        st_ut_eq(0,    s.len,         "len");
-        st_ut_eq(1,    s.capacity,    "capacity");
-        st_ut_eq(0,    s.bytes_owned, "bytes_owned is 0");
-        st_ut_ne(NULL, s.bytes,       "bytes is not NULL");
+        st_ut_eq(ST_TYPES_STRING, s.type,        "type is not string");
+        st_ut_eq(0,               s.len,         "len");
+        st_ut_eq(1,               s.capacity,    "capacity");
+        st_ut_eq(0,               s.bytes_owned, "bytes_owned is 0");
+        st_ut_ne(NULL,            s.bytes,       "bytes is not NULL");
     }
 
 }
@@ -129,11 +131,11 @@ st_test(str, init) {
         ret = st_str_init(&s, 0);
         st_ut_eq(ST_OK, ret, "init ok");
 
-        st_ut_eq(0,    s.type,        "type is 0");
-        st_ut_eq(0,    s.len,         "len is 0");
-        st_ut_eq(1,    s.capacity,    "capacity is 1, because it use a pre-allocated empty c-string");
-        st_ut_eq(0,    s.bytes_owned, "bytes_owned is 0, use pre-allocated empty c-string");
-        st_ut_ne(NULL, s.bytes,       "bytes is not NULL");
+        st_ut_eq(ST_TYPES_STRING, s.type,        "type is not string");
+        st_ut_eq(0,               s.len,         "len is 0");
+        st_ut_eq(1,               s.capacity,    "capacity is 1, because it use a pre-allocated empty c-string");
+        st_ut_eq(0,               s.bytes_owned, "bytes_owned is 0, use pre-allocated empty c-string");
+        st_ut_ne(NULL,            s.bytes,       "bytes is not NULL");
 
         ret = st_str_destroy(&s);
         st_ut_eq(ST_OK, ret, "destroy");
@@ -150,11 +152,11 @@ st_test(str, init) {
         ret = st_str_init(&s, 1);
         st_ut_eq(ST_OK, ret, "init ok");
 
-        st_ut_eq(0,    s.type,        "type is 0");
-        st_ut_eq(1,    s.len,         "len is 0");
-        st_ut_eq(1,    s.capacity,    "capacity is 1");
-        st_ut_eq(1,    s.bytes_owned, "bytes_owned is 1");
-        st_ut_ne(NULL, s.bytes,       "bytes is not NULL");
+        st_ut_eq(ST_TYPES_STRING, s.type,        "type is not string");
+        st_ut_eq(1,               s.len,         "len is 0");
+        st_ut_eq(1,               s.capacity,    "capacity is 1");
+        st_ut_eq(1,               s.bytes_owned, "bytes_owned is 1");
+        st_ut_ne(NULL,            s.bytes,       "bytes is not NULL");
 
         ret = st_str_destroy(&s);
         st_ut_eq(ST_OK, ret, "destroy");
@@ -165,11 +167,11 @@ st_test(str, init) {
         ret = st_str_init(&s, 102400);
         st_ut_eq(ST_OK, ret, "init ok");
 
-        st_ut_eq(0,      s.type,        "type is 0");
-        st_ut_eq(102400, s.len,         "len is 0");
-        st_ut_eq(102400, s.capacity,    "capacity is 1, because it use a pre-allocated empty c-string");
-        st_ut_eq(1,      s.bytes_owned, "bytes_owned is 1");
-        st_ut_ne(NULL,   s.bytes,       "bytes is not NULL");
+        st_ut_eq(ST_TYPES_STRING, s.type,        "type is not string");
+        st_ut_eq(102400,          s.len,         "len is 0");
+        st_ut_eq(102400,          s.capacity,    "capacity is 1, because it use a pre-allocated empty c-string");
+        st_ut_eq(1,               s.bytes_owned, "bytes_owned is 1");
+        st_ut_ne(NULL,            s.bytes,       "bytes is not NULL");
 
         ret = st_str_destroy(&s);
         st_ut_eq(ST_OK, ret, "destroy");
@@ -185,11 +187,11 @@ st_test(str, init_0) {
         ret = st_str_init_0(&s, 0);
         st_ut_eq(ST_OK, ret, "init ok");
 
-        st_ut_eq(0,    s.type,        "type is 0");
-        st_ut_eq(0,    s.len,         "len is 0");
-        st_ut_eq(1,    s.capacity,    "capacity is 1, because it use a pre-allocated empty c-string");
-        st_ut_eq(1,    s.bytes_owned, "bytes_owned is 0, use pre-allocated empty c-string");
-        st_ut_ne(NULL, s.bytes,       "bytes is not NULL");
+        st_ut_eq(ST_TYPES_STRING, s.type,        "type is not string");
+        st_ut_eq(0,               s.len,         "len is 0");
+        st_ut_eq(1,               s.capacity,    "capacity is 1, because it use a pre-allocated empty c-string");
+        st_ut_eq(1,               s.bytes_owned, "bytes_owned is 0, use pre-allocated empty c-string");
+        st_ut_ne(NULL,            s.bytes,       "bytes is not NULL");
 
         ret = st_str_destroy(&s);
         st_ut_eq(ST_OK, ret, "destroy");
@@ -200,11 +202,11 @@ st_test(str, init_0) {
         ret = st_str_init_0(&s, 1);
         st_ut_eq(ST_OK, ret, "init ok");
 
-        st_ut_eq(0,    s.type,        "type is 0");
-        st_ut_eq(1,    s.len,         "len");
-        st_ut_eq(2,    s.capacity,    "capacity is 2");
-        st_ut_eq(1,    s.bytes_owned, "bytes_owned is 1");
-        st_ut_ne(NULL, s.bytes,       "bytes is not NULL");
+        st_ut_eq(ST_TYPES_STRING, s.type,        "type is not string");
+        st_ut_eq(1,               s.len,         "len");
+        st_ut_eq(2,               s.capacity,    "capacity is 2");
+        st_ut_eq(1,               s.bytes_owned, "bytes_owned is 1");
+        st_ut_ne(NULL,            s.bytes,       "bytes is not NULL");
 
         ret = st_str_destroy(&s);
         st_ut_eq(ST_OK, ret, "destroy");
@@ -215,11 +217,11 @@ st_test(str, init_0) {
         ret = st_str_init_0(&s, 102400);
         st_ut_eq(ST_OK, ret, "init ok");
 
-        st_ut_eq(0,      s.type,        "type is 0");
-        st_ut_eq(102400, s.len,         "len");
-        st_ut_eq(102401, s.capacity,    "capacity");
-        st_ut_eq(1,      s.bytes_owned, "bytes_owned is 1");
-        st_ut_ne(NULL,   s.bytes,       "bytes is not NULL");
+        st_ut_eq(ST_TYPES_STRING, s.type,        "type is not string");
+        st_ut_eq(102400,          s.len,         "len");
+        st_ut_eq(102401,          s.capacity,    "capacity");
+        st_ut_eq(1,               s.bytes_owned, "bytes_owned is 1");
+        st_ut_ne(NULL,            s.bytes,       "bytes is not NULL");
 
         ret = st_str_destroy(&s);
         st_ut_eq(ST_OK, ret, "destroy");
@@ -366,6 +368,133 @@ st_test(str, cmp) {
         ddx(rst);
 
         st_ut_eq(c.expected, rst, "");
+
+        char ca[100];
+        char cb[100];
+        memcpy(ca, c.a, strlen(c.a));
+        memcpy(cb, c.b, strlen(c.b));
+
+        a = (st_str_t)st_str_wrap_common(ca, ST_TYPES_CHAR_ARRAY, (strlen(c.a)));
+        b = (st_str_t)st_str_wrap_common(cb, ST_TYPES_CHAR_ARRAY, (strlen(c.b)));
+        rst = st_str_cmp(&a, &b);
+
+        ddx(rst);
+
+        st_ut_eq(c.expected, rst, "");
+    }
+
+    {
+        /** invalid ST_TYPES_TABLE */
+        st_str_t a = st_str_wrap_common(NULL, ST_TYPES_TABLE, 0);
+        st_str_t b = st_str_wrap_common(NULL, ST_TYPES_INTEGER, 0);
+
+        int rst = st_str_cmp(&a, &b);
+        st_ut_eq(ST_ARG_INVALID, rst, "table type should be invalid");
+
+        rst = st_str_cmp(&b, &a);
+        st_ut_eq(ST_ARG_INVALID, rst, "table type should be invalid");
+
+    }
+
+    {
+        /** cmp by different types */
+        for (int t = ST_TYPES_INTEGER; t < ST_TYPES_NIL; t++) {
+            st_str_t a = st_str_wrap_common(NULL, t, 0);
+            st_str_t b = st_str_wrap_common(NULL, t + 1, 0);
+
+            int rst = st_str_cmp(&a, &b);
+            st_ut_eq(-1, rst, "failed to compare types");
+        }
+    }
+
+    {
+        /** int */
+        int values[] = { INT_MIN, -256, -255, -254, -1, 0, 255, INT_MAX-1 };
+        for (int idx = 0; idx < st_nelts(values); idx++) {
+            int ia = values[idx];
+            int ib = ia + 1;
+            st_str_t a = st_str_wrap_common(&ia, ST_TYPES_INTEGER, sizeof(ia));
+            st_str_t b = st_str_wrap_common(&ib, ST_TYPES_INTEGER, sizeof(ib));
+
+            int rst = st_str_cmp(&a, &b);
+            st_ut_eq(-1, rst, "failed to compare int type lt case");
+
+            rst = st_str_cmp(&a, &a);
+            st_ut_eq(0, rst, "failed to compare int type eq case");
+
+            rst = st_str_cmp(&b, &a);
+            st_ut_eq(1, rst, "failed to compare int type gt case");
+        }
+    }
+
+    {
+        /** uint64_t */
+        uint64_t values[] = { 0, 255, ULONG_MAX-1 };
+        for (int idx = 0; idx < st_nelts(values); idx++) {
+            uint64_t u64_a = values[idx];
+            uint64_t u64_b = u64_a + 1;
+
+            st_str_t a = st_str_wrap_common(&u64_a, ST_TYPES_U64, sizeof(u64_a));
+            st_str_t b = st_str_wrap_common(&u64_b, ST_TYPES_U64, sizeof(u64_b));
+
+            int rst = st_str_cmp(&a, &b);
+            st_ut_eq(-1, rst, "failed to compare uint64_t type lt case");
+
+            rst = st_str_cmp(&a, &a);
+            st_ut_eq(0, rst, "failed to compare uint64_t type eq case");
+
+            rst = st_str_cmp(&b, &a);
+            st_ut_eq(1, rst, "failed to compare uint64_t type gt case");
+        }
+    }
+
+    {
+        /** double */
+        double values[] = { -256.0, -255.0, 0.0, 255.0 };
+        for (int idx = 0; idx < st_nelts(values); idx++) {
+            double da = values[idx];
+            double db = da + 1;
+
+            st_str_t a = st_str_wrap_common(&da, ST_TYPES_NUMBER, sizeof(da));
+            st_str_t b = st_str_wrap_common(&db, ST_TYPES_NUMBER, sizeof(db));
+
+            int rst = st_str_cmp(&a, &b);
+            st_ut_eq(-1, rst, "failed to compare double type lt case");
+
+            rst = st_str_cmp(&a, &a);
+            st_ut_eq(0, rst, "failed to compare double type eq case");
+
+            rst = st_str_cmp(&b, &a);
+            st_ut_eq(1, rst, "failed to compare double type gt case");
+        }
+    }
+
+    {
+        /** st_bool */
+        st_bool ba = 0;
+        st_bool bb = 1;
+
+        st_str_t a = st_str_wrap_common(&ba, ST_TYPES_BOOLEAN, sizeof(ba));
+        st_str_t b = st_str_wrap_common(&bb, ST_TYPES_BOOLEAN, sizeof(bb));
+
+        int rst = st_str_cmp(&a, &b);
+        st_ut_eq(-1, rst, "failed to compare st_bool type lt case");
+
+        rst = st_str_cmp(&a, &a);
+        st_ut_eq(0, rst, "failed to compare st_bool type eq case");
+
+        rst = st_str_cmp(&b, &a);
+        st_ut_eq(1, rst, "failed to compare st_bool type gt case");
+
+    }
+
+    {
+        /** null */
+        st_str_t a = st_str_wrap_common(NULL, ST_TYPES_NIL, 0);
+        st_str_t b = st_str_wrap_common(NULL, ST_TYPES_NIL, 0);
+
+        int rst = st_str_cmp(&a, &b);
+        st_ut_eq(0, rst, "failed to comapre nil type case");
     }
 }
 
@@ -394,11 +523,11 @@ st_test(str, destroy) {
     ret = st_str_init(&s, 10);
     st_ut_eq(ST_OK, ret, "init ok");
 
-    st_ut_eq(0,    s.type,        "type is 0");
-    st_ut_eq(10,   s.len,         "len is 10");
-    st_ut_eq(10,   s.capacity,    "capacity is 10");
-    st_ut_eq(1,    s.bytes_owned, "bytes_owned is 1");
-    st_ut_ne(NULL, s.bytes,       "bytes is not NULL");
+    st_ut_eq(ST_TYPES_STRING, s.type,        "type is not string");
+    st_ut_eq(10,              s.len,         "len is 10");
+    st_ut_eq(10,              s.capacity,    "capacity is 10");
+    st_ut_eq(1,               s.bytes_owned, "bytes_owned is 1");
+    st_ut_ne(NULL,            s.bytes,       "bytes is not NULL");
 
     ret = st_str_destroy(&s);
     st_ut_eq(ST_OK, ret, "destroy");
@@ -438,11 +567,11 @@ st_test(str, ref) {
 
     st_ut_eq(1, s.bytes_owned, "target bytes_owned does not change");
 
-    st_ut_eq(0,       ref.type,        "type is 0");
-    st_ut_eq(10,      ref.len,         "len is 0");
-    st_ut_eq(10,      ref.capacity,    "capacity is 0");
-    st_ut_eq(0,       ref.bytes_owned, "bytes_owned is 0, ref does not need to free memory");
-    st_ut_eq(s.bytes, ref.bytes,       "bytes is shared");
+    st_ut_eq(ST_TYPES_STRING, ref.type,        "type is not string");
+    st_ut_eq(10,              ref.len,         "len is 0");
+    st_ut_eq(10,              ref.capacity,    "capacity is 0");
+    st_ut_eq(0,               ref.bytes_owned, "bytes_owned is 0, ref does not need to free memory");
+    st_ut_eq(s.bytes,         ref.bytes,       "bytes is shared");
 
     ret = st_str_destroy(&s);
     st_ut_eq(ST_OK, ret, "destroy s");
@@ -479,11 +608,11 @@ st_test(str, copy) {
 
     st_ut_eq(1, s.bytes_owned, "target bytes_owned does not change");
 
-    st_ut_eq(0,          cpy.type,        "type is 0");
-    st_ut_eq(s.len,      cpy.len,         "len is same as s");
-    st_ut_eq(s.capacity, cpy.capacity,    "capacity is same as s");
-    st_ut_eq(1,          cpy.bytes_owned, "bytes_owned is 1, memory reallocated");
-    st_ut_ne(s.bytes,    cpy.bytes,       "bytes is not shared");
+    st_ut_eq(ST_TYPES_STRING, cpy.type,        "type is not string");
+    st_ut_eq(s.len,           cpy.len,         "len is same as s");
+    st_ut_eq(s.capacity,      cpy.capacity,    "capacity is same as s");
+    st_ut_eq(1,               cpy.bytes_owned, "bytes_owned is 1, memory reallocated");
+    st_ut_ne(s.bytes,         cpy.bytes,       "bytes is not shared");
 
     ret = st_memcmp(s.bytes, cpy.bytes, s.capacity);
     st_ut_eq(0, ret, "cpy.bytes is same as s.bytes");


### PR DESCRIPTION
根据st_str_t中的type字段，按照实际类型比较key。
    避免同种类型的数据由于符号和小端存储导致的大小颠倒问题。
    unknown类型依然按照内存直接比较。

将ST_TYPES_INTEGER类型调整为最小，在rbtree中存储到左下角